### PR TITLE
Correct bug with encoders

### DIFF
--- a/KeyLab.js
+++ b/KeyLab.js
@@ -715,19 +715,19 @@ function setDeviceValue(index, page, increment) {
          sendTextToKeyLab(getMacroName(index), kL.macroValue[index]);
          break;
       case 1:
-         var com1;
-         var com2;
          kL.commonHasChanged[index] = true;
          kL.cDevice.getCommonParameter(index).inc(increment, 128);
-         [com1, com2] = getCommonName(index);
+         var commonName = getCommonName(index);
+         var com1 = commonName[0];
+         var com2 = commonName[1];
          sendTextToKeyLab(com1, com2);
          break;
       default:
-         var def1;
-         var def2;
          kL.parameterHasChanged[index] = true;
          kL.cDevice.getParameter(index).inc(increment, 128);
-         [def1, def2] = getParameterName(index);
+         var paramName = getParameterName(index);
+         var def1 = paramName[0];
+         var def2 = paramName[1];
          sendTextToKeyLab(def1, def2);
          break;
    }
@@ -905,10 +905,10 @@ function getValueObserverFuncCommon(index, varToStore, name, varToTest) {
    return function(value) {
       varToStore[index] = value;
       if (varToTest[index]) {
-         var temp1;
-         var temp2;
          varToTest[index] = false;
-         [temp1, temp2] = name(index);
+         var names = name(index);
+         var temp1 = names[0];
+         var temp2 = names[1];
          if (temp2 === "") {
             sendTextToKeyLab(temp1, temp2);
          }

--- a/KeyLab25.control.js
+++ b/KeyLab25.control.js
@@ -8,7 +8,7 @@ load ("KeyLab.js");
 DRUMPADS = false;
 CNAME = "KeyLab 25";
 
-host.defineController("Arturia", "KeyLab 25", "1.0", "360d96b0-0210-11e4-9191-0800200c9a66");
+host.defineController("Arturia", "KeyLab 25", "1.1", "360d96b0-0210-11e4-9191-0800200c9a66");
 host.defineMidiPorts(1, 1);
 host.addDeviceNameBasedDiscoveryPair(["KeyLab 25"], ["KeyLab 25"]);
 host.defineSysexIdentityReply("F0 7E 00 06 02 00 20 6B ?? ?? 05 00 ?? ?? ?? ?? F7");

--- a/KeyLab49.control.js
+++ b/KeyLab49.control.js
@@ -8,7 +8,7 @@ load ("KeyLab.js");
 DRUMPADS = true;
 CNAME = "KeyLab 49";
 
-host.defineController("Arturia", "KeyLab 49", "1.0", "faa89c00-020a-11e4-9191-0800200c9a66");
+host.defineController("Arturia", "KeyLab 49", "1.1", "faa89c00-020a-11e4-9191-0800200c9a66");
 host.defineMidiPorts(1, 1);
 host.addDeviceNameBasedDiscoveryPair(["KeyLab 49"], ["KeyLab 49"]);
 host.defineSysexIdentityReply("F0 7E 00 06 02 00 20 6B ?? ?? 05 02 ?? ?? ?? ?? F7");

--- a/KeyLab61.control.js
+++ b/KeyLab61.control.js
@@ -8,7 +8,7 @@ load ("KeyLab.js");
 DRUMPADS = true;
 CNAME = "KeyLab 61";
 
-host.defineController("Arturia", "KeyLab 61", "1.0", "2d1a0610-0210-11e4-9191-0800200c9a66");
+host.defineController("Arturia", "KeyLab 61", "1.1", "2d1a0610-0210-11e4-9191-0800200c9a66");
 host.defineMidiPorts(1, 1);
 host.addDeviceNameBasedDiscoveryPair(["KeyLab 61"], ["KeyLab 61"]);
 host.defineSysexIdentityReply("F0 7E 00 06 02 00 20 6B ?? ?? 05 04 ?? ?? ?? ?? F7");

--- a/KeyLabInit.js
+++ b/KeyLabInit.js
@@ -120,9 +120,9 @@ function configureEncoder(index, cc, relative) {
    var min = uint7ToHex(0);
    var max = uint7ToHex(127);
 
-   sendSysex("F0 00 20 6B 7F 42 02 00 01" + indexHex + mode + "F7");
-   sendSysex("F0 00 20 6B 7F 42 02 00 02" + indexHex + "00 F7");
-   sendSysex("F0 00 20 6B 7F 42 02 00 03" + indexHex + ccHex + "F7");
-   sendSysex("F0 00 20 6B 7F 42 02 00 04" + indexHex + min + "F7");
-   sendSysex("F0 00 20 6B 7F 42 02 00 05" + indexHex + max + "F7");
+   sendSysex("F0 00 20 6B 7F 42 02 00 01 " + indexHex + mode + "F7");
+   sendSysex("F0 00 20 6B 7F 42 02 00 02 " + indexHex + "00 F7");
+   sendSysex("F0 00 20 6B 7F 42 02 00 03 " + indexHex + ccHex + "F7");
+   sendSysex("F0 00 20 6B 7F 42 02 00 04 " + indexHex + min + "F7");
+   sendSysex("F0 00 20 6B 7F 42 02 00 05 " + indexHex + max + "F7");
 }

--- a/MiniLab.control.js
+++ b/MiniLab.control.js
@@ -4,7 +4,7 @@ loadAPI(1);
 
 load ("Extensions.js");
 
-host.defineController("Arturia", "MiniLab", "1.0", "e48ffd90-3203-11e4-8c21-0800200c9a66");
+host.defineController("Arturia", "MiniLab", "1.1", "e48ffd90-3203-11e4-8c21-0800200c9a66");
 host.defineMidiPorts(1, 1);
 host.addDeviceNameBasedDiscoveryPair(["Arturia MINILAB"], ["Arturia MINILAB"]);
 host.addDeviceNameBasedDiscoveryPair(["Arturia MINILAB MIDI 1"], ["Arturia MINILAB MIDI 1"]);

--- a/Modes.js
+++ b/Modes.js
@@ -147,11 +147,11 @@ SOUND_MODE.onEncoder = function(index, inc) {
 };
 
 SOUND_MODE.onFader = function(index, value) {
-   var env1;
-   var env2;
    kL.envelopeHasChanged[index] = true;
    kL.cDevice.getEnvelopeParameter(index).set(value, 128);
-   [env1, env2] = getEnvelopeName(index);
+   var envelopeName = getEnvelopeName(index);
+   var env1 = envelopeName[0];
+   var env2 = envelopeName[1];
    sendTextToKeyLab(env1, env2);
 };
 


### PR DESCRIPTION
I noticed that my encoder knobs weren't working correctly and dug into possible reasons. The issue that I noticed is that knobs 2, 4, 6, 8 and 10 on my KeyLab would get jumpy when changing parameters and it made it not reliable to use to adjust parameter values within Bitwig. As I looked at the values each knob was rendering it seemed that some knobs were set to "relative" mode (those are the ones that worked) and some were still on "absolute" mode (these are the ones that failed to work consistently). For whatever reason, the bug was related to every other knob being set to the correct mode.

I tracked down the cause of the error in the `configureEncoder` function in `KeyLabInit.js`

When it was sending SysEx values, it was generating as an example this value:
`F0 00 20 6B 7F 42 02 00 0133 02 F7`

And it should be generating this value (note the space between 01 and 33):
`F0 00 20 6B 7F 42 02 00 01 33 02 F7`

The key correction is this line in `KeyLabInit.js`, changing this:
```
   sendSysex("F0 00 20 6B 7F 42 02 00 01" + indexHex + mode + "F7");
```
to this:
```
   sendSysex("F0 00 20 6B 7F 42 02 00 01 " + indexHex + mode + "F7");
```

The other change in this pull request was something that seemed to be necessary due to a change js parsing library that Bitwig uses. It doesn't allow setting multiple variables from a list, e.g. `[foo, bar] = functionThatReturnsList()`

Note, I have tested this using Bitwig Studio 3 Beta 4 with my Keylab 49 mark I, but I noticed this knob issue was a problem in previous versions of Bitwig Studio.